### PR TITLE
adds leaflet map containing an image of the planets 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6064,6 +6064,11 @@
         "invert-kv": "^2.0.0"
       }
     },
+    "leaflet": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.5.1.tgz",
+      "integrity": "sha512-ekM9KAeG99tYisNBg0IzEywAlp0hYI5XRipsqRXyRTeuU8jcuntilpp+eFf5gaE0xubc9RuSNIVtByEKwqFV0w=="
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -9850,6 +9855,11 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
+    },
+    "vue2-leaflet": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/vue2-leaflet/-/vue2-leaflet-2.2.1.tgz",
+      "integrity": "sha512-yBB3Ilv9LTszNn/uxUATq8+Ahw/1FqIasdQehb9m1tJ5T9qeEk8Fr9a6uLzvR+zuz88rnEQVo7/iGUd96E7iLg=="
     },
     "watchpack": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
   },
   "dependencies": {
     "core-js": "^2.6.5",
+    "leaflet": "^1.2.11",
     "vue": "^2.6.10",
-    "vue-router": "^3.1.3"
+    "vue-router": "^3.1.3",
+    "vue2-leaflet": "^2.2.1"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.11.0",

--- a/src/components/PlanetLeaflet.vue
+++ b/src/components/PlanetLeaflet.vue
@@ -1,31 +1,78 @@
 <template lang="html">
   <div id="main">
     <h1>Your Codessy Across Our Solar System</h1>
-    <div class="image">
-      <img src="../assets/solar-system.jpg" alt="planets">
+    <div id="mapid">
+      <l-map ref="myMap" :minZoom="minZoom" :maxZoom="maxZoom" :max-bounds="maxBounds" :crs="crs">
+
+        <l-image-overlay :url="url" :bounds="bounds"/>
+
+        <l-marker v-for="planet in planets" :lat-lng="planet" :key="planet.name">
+          <l-popup :content="planet.name" />
+        </l-marker>
+
+      </l-map>
     </div>
   </div>
 </template>
 
 <script>
+import {CRS} from 'leaflet';
+import {LMap, LImageOverlay, LMarker, LPopup} from 'vue2-leaflet';
+
 export default {
-  name: "planet-leaflet"
+  name: "planet-leaflet",
+  components: {
+    LMap,
+    LImageOverlay,
+    LMarker,
+    LPopup
+  },
+  data(){
+    return {
+      url: "https://cdn.pixabay.com/photo/2014/09/08/09/24/solar-system-439046_1280.jpg",
+      bounds:[[-300, 0], [0, 1000]],
+      maxBounds:[[-300, 0], [0, 1000]],
+      minZoom: 0,
+      maxZoom: 2,
+      crs: CRS.Simple,
+      planets:[
+        {name: "Sun", lat:-150, lng: 35},
+        {name: "Mercury", lat:-150, lng: 115},
+        {name: "Venus", lat:-150, lng: 165},
+        {name: "Earth", lat:-150, lng: 240},
+        {name: "Mars", lat:-150, lng: 315},
+        {name: "Jupiter", lat:-150, lng: 460},
+        {name: "Saturn", lat:-150, lng: 620},
+        {name: "Uranus", lat:-150, lng: 780},
+        {name: "Neptune", lat:-150, lng: 890},
+      ],
+      mapx: null,
+      mapy: null
+    }
+  },
+  mounted () {
+      this.$refs.myMap.mapObject.fitBounds(this.bounds);
+  }
 }
 </script>
 
 <style lang="css" scoped>
-img{
-  height: 18em;
-  width: 95%;
-  margin-bottom: 1em;
-  border-radius: 8px;
-}
+
 h1{
   margin-top: 0;
 }
 
-.image {
-  display: flex;
-  justify-content: center;
+#mapid {
+  height: 300px;
+  width: 1000px;
+  margin: 0 auto;
+  margin-bottom: 1em;
+  border: 1px white solid;
+  border-radius: 8px;
+}
+.leaflet-container {
+    background-color:rgba(255,0,0,0.0);
+    border-radius: 8px;
+
 }
 </style>

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,19 @@
 import Vue from 'vue';
 import App from './App.vue';
 
+import {LMap, LTileLayer, LMarker, LPopup} from 'vue2-leaflet'
+import { Icon, CRS } from 'leaflet'
+import 'leaflet/dist/leaflet.css'
+
+//without the below the icons don't show up
+delete Icon.Default.prototype._getIconUrl;
+
+Icon.Default.mergeOptions({
+  iconRetinaUrl: require('leaflet/dist/images/marker-icon-2x.png'),
+  iconUrl: require('leaflet/dist/images/marker-icon.png'),
+  shadowUrl: require('leaflet/dist/images/marker-shadow.png')
+});
+
 import router from './router.js';
 
 Vue.config.productionTip = false;


### PR DESCRIPTION
default icons are used, but they identify planet names, and the image can be zoomed but not dragged outside of the image.

don't forget you'll need to `npm i` again to install leaflet. 